### PR TITLE
Add webpack 4 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "node": ">= 4.3 < 5.0.0 || >= 5.10"
   },
   "peerDependencies": {
-    "webpack": "^2.0.0 || ^3.0.0"
+    "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "homepage": "https://webpack.js.org",
   "repository": {


### PR DESCRIPTION
Fixes #11.

I haven't tested this more thoroughly than ignoring the warning in my own project, but that seems to work...

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
